### PR TITLE
Public KeyType and ValueType

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Go template
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+

--- a/orderedmap.go
+++ b/orderedmap.go
@@ -5,6 +5,7 @@ package orderedmap
 import (
 	"bytes"
 	"encoding/json"
+	"github.com/ghodss/yaml"
 )
 
 type KeyType string
@@ -162,4 +163,35 @@ func (kv KV) MarshalJSON() ([]byte, error) {
 
 	buffer.WriteString("}")
 	return buffer.Bytes(), nil
+}
+
+// MarshalYAML Marshalls the ordered map to yaml
+func (om *OrderedMap) MarshalYAML() ([]byte, error) {
+	jsonBytes, err := om.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	yamlBytes, err := yaml.JSONToYAML(jsonBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return yamlBytes, err
+}
+
+// MarshalYAML Marshals the ordered map to yaml
+func (kv KV) MarshalYAML() ([]byte, error) {
+	jsonBytes, err := kv.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	yamlBytes, err := yaml.JSONToYAML(jsonBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return yamlBytes, err
+
 }

--- a/orderedmap.go
+++ b/orderedmap.go
@@ -7,23 +7,23 @@ import (
 	"encoding/json"
 )
 
-type keyType string
-type valueType interface{}
+type KeyType string
+type ValueType interface{}
 
 type KV struct {
-	Key   keyType
-	Value valueType
+	Key   KeyType
+	Value ValueType
 }
 
 type OrderedMap struct {
 	kvList    []*KV
-	idxLookup map[keyType]int
+	idxLookup map[KeyType]int
 }
 
 // Creates new ordered map
 func NewOrderedMap(kvList ...*KV) (om *OrderedMap) {
 	om = &OrderedMap{
-		idxLookup: make(map[keyType]int),
+		idxLookup: make(map[KeyType]int),
 	}
 
 	for i := 0; i < len(kvList); i++ {
@@ -33,7 +33,7 @@ func NewOrderedMap(kvList ...*KV) (om *OrderedMap) {
 }
 
 // Sets value for given key
-func (om *OrderedMap) Set(key keyType, value valueType) *OrderedMap {
+func (om *OrderedMap) Set(key KeyType, value ValueType) *OrderedMap {
 	if idx, ok := om.idxLookup[key]; !ok {
 		// insert new key value pair
 		om.idxLookup[key] = len(om.kvList)
@@ -47,7 +47,7 @@ func (om *OrderedMap) Set(key keyType, value valueType) *OrderedMap {
 }
 
 // Returns the given key's value or <nil> if key does not exist
-func (om *OrderedMap) Get(key keyType) valueType {
+func (om *OrderedMap) Get(key KeyType) ValueType {
 	if idx, ok := om.idxLookup[key]; ok {
 		return om.kvList[idx].Value
 	}
@@ -55,12 +55,12 @@ func (om *OrderedMap) Get(key keyType) valueType {
 }
 
 // Checks for existence of a given key
-func (om *OrderedMap) Exists(key keyType) (ok bool) {
+func (om *OrderedMap) Exists(key KeyType) (ok bool) {
 	_, ok = om.idxLookup[key]
 	return
 }
 
-func (obj *OrderedMap) Delete(key keyType) {
+func (obj *OrderedMap) Delete(key KeyType) {
 	if idx, ok := obj.idxLookup[key]; ok {
 		delete(obj.idxLookup, key)
 		obj.kvList[idx] = nil
@@ -68,7 +68,7 @@ func (obj *OrderedMap) Delete(key keyType) {
 }
 
 // Returns ordered list of keys
-func (om *OrderedMap) GetKeys() (keys []keyType) {
+func (om *OrderedMap) GetKeys() (keys []KeyType) {
 	for idx := 0; idx < len(om.kvList); idx++ {
 		if om.kvList[idx] != nil {
 			keys = append(keys, om.kvList[idx].Key)

--- a/orderedmap_test.go
+++ b/orderedmap_test.go
@@ -1,0 +1,1 @@
+package orderedmap

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,0 +1,61 @@
+{
+	"comment": "",
+	"ignore": "test",
+	"package": [
+		{
+			"checksumSHA1": "CSPbwbyzqA6sfORicn4HFtIhF/c=",
+			"path": "github.com/davecgh/go-spew/spew",
+			"revision": "8991bc29aa16c548c550c7ff78260e27b9ab7c73",
+			"revisionTime": "2018-02-21T22:46:20Z"
+		},
+		{
+			"checksumSHA1": "ImX1uv6O09ggFeBPUJJ2nu7MPSA=",
+			"path": "github.com/ghodss/yaml",
+			"revision": "0ca9ea5df5451ffdf184b4428c902747c2c11cd7",
+			"revisionTime": "2017-03-27T23:54:44Z"
+		},
+		{
+			"checksumSHA1": "LuFv4/jlrmFNnDb/5SCSEPAM9vU=",
+			"path": "github.com/pmezard/go-difflib/difflib",
+			"revision": "792786c7400a136282c1664665ae0a8db921c6c2",
+			"revisionTime": "2016-01-10T10:55:54Z"
+		},
+		{
+			"checksumSHA1": "6thzskcj6XrMO5kW6GlRiuTDYjU=",
+			"path": "github.com/stretchr/objx",
+			"revision": "8a3f7159479fbc75b30357fbc48f380b7320f08e",
+			"revisionTime": "2018-01-29T17:20:03Z"
+		},
+		{
+			"checksumSHA1": "nj123dGxKPIF17B6y3VEK2pihRk=",
+			"path": "github.com/stretchr/testify",
+			"revision": "c679ae2cc0cb27ec3293fea7e254e47386f05d69",
+			"revisionTime": "2018-03-14T08:05:35Z"
+		},
+		{
+			"checksumSHA1": "6LwXZI7kXm1C0h4Ui0Y52p9uQhk=",
+			"path": "github.com/stretchr/testify/assert",
+			"revision": "c679ae2cc0cb27ec3293fea7e254e47386f05d69",
+			"revisionTime": "2018-03-14T08:05:35Z"
+		},
+		{
+			"checksumSHA1": "fg3TzS9/QK3wZbzei3Z6O8XPLHg=",
+			"path": "github.com/stretchr/testify/http",
+			"revision": "c679ae2cc0cb27ec3293fea7e254e47386f05d69",
+			"revisionTime": "2018-03-14T08:05:35Z"
+		},
+		{
+			"checksumSHA1": "Qloi2PTvZv+D9FDHXM/banCoaFY=",
+			"path": "github.com/stretchr/testify/mock",
+			"revision": "c679ae2cc0cb27ec3293fea7e254e47386f05d69",
+			"revisionTime": "2018-03-14T08:05:35Z"
+		},
+		{
+			"checksumSHA1": "ZSWoOPUNRr5+3dhkLK3C4cZAQPk=",
+			"path": "gopkg.in/yaml.v2",
+			"revision": "5420a8b6744d3b0345ab293f6fcba19c978f1183",
+			"revisionTime": "2018-03-28T19:50:20Z"
+		}
+	],
+	"rootPath": "github.com/nikogura/orderedmap"
+}


### PR DESCRIPTION
Changed keyType and valueType to KeyType and ValueType so that they're accessable outside the package and you can do type assertions against them and set dynamic keys.

Otherwise things like this fail:

stringKey := "foo"
someValue := "bar"
orderedMap := om.NewOrderedMap()

orderedMap.set(stringKey, someValue)

Thanks for such a great package though.  Really appreciate it.